### PR TITLE
Github link to main project rather than docs repo in the docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: Building declarative APIs
 site_author: Joe Nelson
 site_favicon: favicon.ico
 
-repo_url: https://github.com/begriffs/postgrest-docs
+repo_url: https://github.com/begriffs/postgrest
 
 pages:
 - Home: index.md


### PR DESCRIPTION
@NikolayS suggested that the main use case on the docs is to go try the program rather than contribute to docs, hence the changed link. Seem good?