### PR TITLE
Suggest swap file on systems with under 1GB of ram

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -75,6 +75,10 @@ When a pre-built binary does not exist for your system you can build the project
     cd postgrest
     stack build --install-ghc
     sudo stack install --allow-different-user --local-bin-path /usr/local/bin
+    
+.. note::
+
+   If building fails and your system has less than 1GB of memory, try adding a swap file.
 
 * Check that the server is installed: :code:`postgrest --help`.
 


### PR DESCRIPTION
Builds of 0.4 repeatedly fail on the first dependency when building on a Digital Ocean Ubuntu 16.04 box with 1GB of ram. Adding 2GB of swap fixed the issue.