### PR TITLE
Fix the plurality header docs for v0.4

### DIFF
--- a/admin.rst
+++ b/admin.rst
@@ -248,7 +248,7 @@ As discussed in `Singular or Plural`_, there are no special URL forms for singul
 .. code:: http
 
   GET /people?id=eq.1
-  Prefer: plurality=singular
+  Accept: application/vnd.pgrst.object+json
 
 This allows compound primary keys and makes the intent for singular response independent of a URL convention. However for any table which uses a simple primary key you can use Nginx to simulate the familiar URL convention.
 

--- a/api.rst
+++ b/api.rst
@@ -218,12 +218,12 @@ By default PostgREST returns all JSON results in an array, even when there is on
     { "id": 1 }
   ]
 
-This can be inconvenient for client code. To return the first result as an object unenclosed by an array, Include a Prefer request header
+This can be inconvenient for client code. To return the first result as an object unenclosed by an array, specify :code:`vnd.pgrst.object` as part of the :code:`Accept` header
 
 .. code:: http
 
   GET /items?id=eq.1 HTTP/1.1
-  Prefer: plurality=singular
+  Accept: application/vnd.pgrst.object+json
 
 This returns
 


### PR DESCRIPTION
The current documentation reflects the headers that must be set for singular object responses in postgrest v0.3. This change updates the documentation to reflect the way it works in v0.4, as noted by @begriffs in https://github.com/begriffs/postgrest/issues/776#issuecomment-275026837

I hope I got it right :)