### PR TITLE
Override document title for index.rst

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,3 +1,5 @@
+.. title:: PostgREST Documentation
+
 .. image:: _static/logo.png
 
 .. toctree::


### PR DESCRIPTION
The index page has `<no-title> -- PostgREST 0.4.0.0 Documentation` for HTML title, using the `title` directive, we can force it to something nicer.
I'm not sure if this fixes it at the top of the page.

http://docutils.sourceforge.net/docs/ref/rst/directives.html#metadata-document-title
http://www.sphinx-doc.org/en/stable/rest.html#directives