### PR TITLE
Auth0 -- app metadata instead of user metadata

### DIFF
--- a/auth.rst
+++ b/auth.rst
@@ -236,14 +236,14 @@ An external service like `Auth0 <https://auth0.com/>`_ can do the hard work tran
 
 To use Auth0, copy its client secret into your PostgREST configuration file as the :code:`jwt-secret`. (Old-style Auth0 secrets are Base64 encoded. For these secrets set :code:`secret-is-base64` to :code:`true`, or just refresh the Auth0 secret.) You can find the secret in the client settings of the Auth0 management console.
 
-Our code requires a database role in the JWT. To add it you need to save the database role in Auth0 `user metadata <https://auth0.com/docs/rules/metadata-in-rules>`_. Then, you will need to write a rule that will extract the role from the user metadata and include a :code:`role` claim in the payload of our user object. Afterwards, in your Auth0Lock code, include the :code:`role` claim in your `scope param <https://auth0.com/docs/libraries/lock/v10/sending-authentication-parameters#scope-string->`_.
+Our code requires a database role in the JWT. To add it you need to save the database role in Auth0 `app metadata <https://auth0.com/docs/rules/metadata-in-rules>`_. Then, you will need to write a rule that will extract the role from the user metadata and include a :code:`role` claim in the payload of our user object. Afterwards, in your Auth0Lock code, include the :code:`role` claim in your `scope param <https://auth0.com/docs/libraries/lock/v10/sending-authentication-parameters#scope-string->`_.
 
 .. code:: javascript
 
   // Example Auth0 rule
   function (user, context, callback) {
-    var role = user.user_metadata.role;
-    user.role = role;
+    user.app_metadata = user.app_metadata || {};
+    user.role = user.app_metadata.role;
     callback(null, user, context);
   }
 


### PR DESCRIPTION
From the [docs](https://auth0.com/docs/metadata):
> An authenticated user can modify data in their profile's `user_metadata`, but not in their `app_metadata`.

Seems role-type information should be stored in `app_metadata`. For s'curity
