### PR TITLE
Add notice about reverting OIDC default

### DIFF
--- a/auth.rst
+++ b/auth.rst
@@ -204,6 +204,16 @@ An external service like `Auth0 <https://auth0.com/>`_ can do the hard work tran
 
 To use Auth0, copy its client secret into your PostgREST configuration file as the :code:`jwt-secret`. (Old-style Auth0 secrets are Base64 encoded. For these secrets set :code:`secret-is-base64` to :code:`true`, or just refresh the Auth0 secret.) You can find the secret in the client settings of the Auth0 management console.
 
+.. note::
+
+  Make sure OIDC-conformant is toggled off.
+
+  A recent Auth0 change sets it on by default. Turn it `off` here:
+
+  Clients > `Your App` > Settings > Show Advanced Settings > OAuth > OIDC Conformant
+
+  Ensure also that your client application does not pass in any `audience` configuration.
+
 Our code requires a database role in the JWT. To add it you need to save the database role in Auth0 `app metadata <https://auth0.com/docs/rules/metadata-in-rules>`_. Then, you will need to write a rule that will extract the role from the user metadata and include a :code:`role` claim in the payload of our user object. Afterwards, in your Auth0Lock code, include the :code:`role` claim in your `scope param <https://auth0.com/docs/libraries/lock/v10/sending-authentication-parameters#scope-string->`_.
 
 .. code:: javascript


### PR DESCRIPTION
Auth0 is pushing users to a new authentication process.
To this end, they've made default a setting that postgrest cannot yet accommodate. See details in begriffs/postgrest#906.

Users can continue integrating with Auth0 if they
 - Toggle off OIDC-conformant authentiction, which, as of yesterday, is default for new clients
 - Remove `audience` configuration from the call to auth0's authentication endpoint
  This configuration has been added to the example integrations

To see current broken setup:

 1. Create rule
```
function (user, context, callback) {
  user.role = 'basic_user'
  callback(null, user, context);
}
```
 2. Create new Auth0 client in dashboard
 3. Download the sample js app; `npm install`; `serve 8080`
 4. In `app.js` change in `webAuth` config:
  - Change `scope: 'openid'` to `scope: 'openid role'`
  - Change `responseType: 'token id_token'` to `responseType: 'token'`
 5. Open `localhost:8080`, login, capture `id_token` from hash, decode [here](https://jwt.io/#encoded-jwt)
 6. Verify token does not include `role`

To fix:

 1. Toggle off `OIDC-compliant` as described in PR's note
 2. In `app.js` change in `webAuth` config:
 - remove `audience` entry
 3. Refresh the page, login, capture `id_token` from hash, decode at jwt.io, verify claim `role: basic_user` is included



Doesn't solve #85, but it's a step in the right direction.