### PR TITLE
Fix typo - 'Connect to to SQL console'

### DIFF
--- a/tutorials/tut0.rst
+++ b/tutorials/tut0.rst
@@ -91,7 +91,7 @@ If everything is working correctly it will print out its version and information
 Step 4. Create Database for API
 -------------------------------
 
-Connect to to SQL console (psql) inside the container. To do so, run this from your command line:
+Connect to the SQL console (psql) inside the container. To do so, run this from your command line:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Replace `to to ` with `to the `.  Alternative was remove the second `to `.  Thoughts?