### PR TITLE
docker-compose: remove optional quotes around environment variable

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -160,7 +160,7 @@ To avoid having to install the database at all, you can run both it and the serv
         PGRST_DB_URI: postgres://app_user:password@db:5432/app_db
         PGRST_DB_SCHEMA: public
         PGRST_DB_ANON_ROLE: app_user #In production this role should not be the same as the one used for the connection
-        PGRST_OPENAPI_SERVER_PROXY_URI: "http://127.0.0.1:3000"
+        PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
       depends_on:
         - db
     db:


### PR DESCRIPTION
See #446 - as the quotes are optional, they can be misleading.