### PR TITLE
remove wrong claim about CSV being faster

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1748,7 +1748,7 @@ URL encoded payloads can be posted with ``Content-Type: application/x-www-form-u
 Bulk Insert
 -----------
 
-Bulk insert works exactly like single row insert except that you provide either a JSON array of objects having uniform keys, or lines in CSV format. This not only minimizes the HTTP requests required but uses a single INSERT statement on the back-end for efficiency. Note that using CSV requires less parsing on the server and is much faster.
+Bulk insert works exactly like single row insert except that you provide either a JSON array of objects having uniform keys, or lines in CSV format. This not only minimizes the HTTP requests required but uses a single INSERT statement on the back-end for efficiency.
 
 To bulk insert CSV simply post to a table route with :code:`Content-Type: text/csv` and include the names of the columns as the first row. For instance
 


### PR DESCRIPTION
On https://postgrest.org/en/latest/api.html#bulk-insert. This is no longer true as we translate CSV in Haskell code and then we use JSON for processing it on postgresql. This might change later.