### PR TITLE
Fix Sphinx version error in RTD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docutils==0.17.1
-sphinx==5.0.2
+sphinx>=5.0.2
 sphinx-copybutton
 sphinx-rtd-theme>=0.5.1
 sphinx-tabs>=3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docutils==0.16
+docutils==0.17.1
 sphinx==5.0.2
 sphinx-copybutton
 sphinx-rtd-theme>=0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docutils==0.16
-sphinx>=4.3.0
+sphinx==5.0.2
 sphinx-copybutton
 sphinx-rtd-theme>=0.5.1
 sphinx-tabs==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ docutils==0.16
 sphinx==5.0.2
 sphinx-copybutton
 sphinx-rtd-theme>=0.5.1
-sphinx-tabs==3.2.0
+sphinx-tabs>=3.2.0
 urllib3==2.0.7
 sphinxext-opengraph==0.9.0


### PR DESCRIPTION
Fixing the "Sphinx version error" in RTD:

```log
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```