### PR TITLE
Fix technical_specs in sample DB using UNIQUE instead of PRIMARY KEY

### DIFF
--- a/docs/references/api/resource_embedding.rst
+++ b/docs/references/api/resource_embedding.rst
@@ -57,11 +57,11 @@ For example, consider a database of films and their awards:
       language text
     );
 
-    CREATE TABLE technical_specs(
-      film_id INT REFERENCES films UNIQUE,
-      runtime TIME,
-      camera TEXT,
-      sound TEXT
+    create table technical_specs(
+      film_id int references films(id) primary key,
+      runtime time,
+      camera text,
+      sound text
     );
 
     create table roles(
@@ -216,11 +216,11 @@ One-to-one relationships are detected in two ways.
 
   .. code-block:: postgresql
 
-    CREATE TABLE technical_specs(
-      film_id INT REFERENCES films UNIQUE,
-      runtime TIME,
-      camera TEXT,
-      sound TEXT
+    create table technical_specs(
+      film_id int references films(id) unique,
+      runtime time,
+      camera text,
+      sound text
     );
 
 .. code-block:: bash


### PR DESCRIPTION
In [the 1to1 embed example](https://postgrest.org/en/latest/references/api/resource_embedding.html#one-to-one-relationships), the docs mention that the sample DB uses a PRIMARY KEY, but it does not.

Also changed to lower case for consistency with other examples.